### PR TITLE
Documentation for attributes

### DIFF
--- a/core-scroll-header-panel.html
+++ b/core-scroll-header-panel.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 
-<polymer-element name="core-scroll-header-panel" attributes="tallMode noDissolve noReveal fixed headerHeight minHeaderHeight">
+<polymer-element name="core-scroll-header-panel">
 <template>
 
   <link rel="stylesheet" href="core-scroll-header-panel.css">
@@ -47,30 +47,67 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      *
      * @event scroll
      */
-    
-    // If true, header is a tall header and as user scrolls, it condenses to 
-    // make more room for the content area.
-    tallMode: false,
-    
-    // If true, no cross-fade transition from one background to another.
-    noDissolve: false,
-    
-    // If true, the header doesn't slide back in when scrolling back up.
-    noReveal: false,
-    
-    // If true, the header is fixed to the top and never moves away.
-    fixed: false,
-    
-    // The height of the header when it is at its full size. scroll-header-panel
-    // will try to measure the header height so users usually don't need to 
-    // set this.
-    headerHeight: 0,
-    
-    // The height of the header when it is condensed.  scroll-header-panel will
-    // set this value to be 1/3 of the headerHeight.  Override the default value
-    // if you want a different height.
-    minHeaderHeight: 0,
-    
+
+    publish: {
+      /**
+       * If true, the header's height will condense to `condensedHeaderHeight`
+       * as the user scrolls down from the top of the content area.
+       *
+       * @attribute condenses
+       * @type boolean
+       * @default false
+       */
+      condenses: false,
+
+      /**
+       * If true, no cross-fade transition from one background to another.
+       *
+       * @attribute noDissolve
+       * @type boolean
+       * @default false
+       */
+      noDissolve: false,
+
+      /**
+       * If true, the header doesn't slide back in when scrolling back up.
+       *
+       * @attribute noReveal
+       * @type boolean
+       * @default false
+       */
+      noReveal: false,
+
+      /**
+       * If true, the header is fixed to the top and never moves away.
+       *
+       * @attribute fixed
+       * @type boolean
+       * @default false
+       */
+      fixed: false,
+
+      /**
+       * The height of the header when it is at its full size.
+       *
+       * By default, the height will be calculated based on the content contained
+       * within it. You generally don't need to set this.
+       *
+       * @attribute headerHeight
+       * @type number
+       */
+      headerHeight: 0,
+
+      /**
+       * The height of the header when it is condensed.
+       *
+       * By default, this will be ⅓ of `headerHeight`.
+       *
+       * @attribute condensedHeaderHeight
+       * @type number
+       */
+      condensedHeaderHeight: 0,
+    },
+
     prevScrollTop: 0,
     
     y: 0,
@@ -93,16 +130,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     
     headerHeightChanged: function() {
       this.fixedChanged();
-      if (this.minHeaderHeight) {
-        this.minHeaderHeightChanged();
+      if (this.condensedHeaderHeight) {
+        this.condensedHeaderHeightChanged();
       } else {
-        // assume minHeaderHeight is 1/3 of the headerHeight
-        this.minHeaderHeight = this.headerHeight * 1 / 3;
+        // assume condensedHeaderHeight is 1/3 of the headerHeight
+        this.condensedHeaderHeight = this.headerHeight * 1 / 3;
       }
     },
-    
-    minHeaderHeightChanged: function() {
-      this.headerMargin = this.headerHeight - this.minHeaderHeight;
+
+    condensedHeaderHeightChanged: function() {
+      this.headerMargin = this.headerHeight - this.condensedHeaderHeight;
     },
     
     fixedChanged: function() {
@@ -119,8 +156,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     transformHeader: function(y) {
       var s = this.$.headerContainer.style;
       this.translateY(s, -y);
-      
-      if (this.tallMode) {
+
+      if (this.condenses) {
         // adjust top bar in core-header so the top bar stays at the top
         if (this.header.$ && this.header.$.topBar) {
           s = this.header.$.topBar.style;
@@ -141,9 +178,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this.translateY(s, y / 2);
         }
       }
-      
-      this.fire('core-header-transform', 
-          {y: y, h: this.headerHeight, minh: this.minHeaderHeight});
+
+      this.fire('core-header-transform',
+          {y: y, h: this.headerHeight, minh: this.condensedHeaderHeight});
     },
     
     translateY: function(s, y) {
@@ -156,11 +193,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       
       var sTop = this.$.mainContainer.scrollTop;
-      
-      var y = Math.min(this.headerHeight, Math.max(0, 
+
+      var y = Math.min(this.headerHeight, Math.max(0,
           (this.noReveal ? sTop : this.y + sTop - this.prevScrollTop)));
-      
-      if (this.tallMode && this.prevScrollTop > sTop && sTop > this.headerMargin) {
+
+      if (this.condenses && this.prevScrollTop > sTop && sTop > this.headerMargin) {
         y = Math.max(y, this.headerMargin);
       }
       

--- a/demos/demo2.html
+++ b/demos/demo2.html
@@ -52,8 +52,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body unresolved>
 
-  <core-scroll-header-panel tallMode>
-  
+  <core-scroll-header-panel condenses>
+
     <core-toolbar class="tall">
     
       <core-icon-button icon="arrow-back"></core-icon-button>

--- a/demos/demo3.html
+++ b/demos/demo3.html
@@ -54,8 +54,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body unresolved>
 
-  <core-scroll-header-panel tallMode noReveal noDissolve>
-  
+  <core-scroll-header-panel condenses noReveal noDissolve>
+
     <core-toolbar class="tall">
     
       <div flex></div>

--- a/demos/demo4.html
+++ b/demos/demo4.html
@@ -63,8 +63,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body unresolved>
 
-  <core-scroll-header-panel tallMode>
-  
+  <core-scroll-header-panel condenses>
+
     <core-toolbar class="tall">
     
       <core-icon-button icon="arrow-back"></core-icon-button>

--- a/demos/demo5.html
+++ b/demos/demo5.html
@@ -63,8 +63,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body unresolved>
 
-  <core-scroll-header-panel tallMode>
-  
+  <core-scroll-header-panel condenses>
+
     <core-toolbar class="tall">
     
       <core-icon-button icon="arrow-back"></core-icon-button>

--- a/demos/demo6.html
+++ b/demos/demo6.html
@@ -67,8 +67,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body unresolved>
 
-  <core-scroll-header-panel tallMode minHeaderHeight="64">
-  
+  <core-scroll-header-panel condenses condensedHeaderHeight="64">
+
     <core-toolbar class="tall">
     
       <core-icon-button icon="arrow-back"></core-icon-button>

--- a/demos/demo7.html
+++ b/demos/demo7.html
@@ -64,8 +64,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body unresolved>
 
-  <core-scroll-header-panel tallMode>
-  
+  <core-scroll-header-panel condenses>
+
     <core-toolbar class="tall">
     
       <core-icon-button icon="arrow-back"></core-icon-button>


### PR DESCRIPTION
The interaction between `tallMode` and `minHeaderHeight` was a bit confusing - what do you think about renaming them to `condenses` and `condensedHeaderHeight`?

Otherwise, here's some quick documentation; I think this follows the latest style you folk are using for attribute docs?
