### PR TITLE
Fix header title scale transform for longer titles

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -58,6 +58,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     
     .title {
+      -webkit-transform-origin: 0;
+      transform-origin: 0;
       font-size: 40px;
     }
     


### PR DESCRIPTION
The current custom resizing of the header title works great for short titles like "Title", but if you put in anything longer, it creates weird spacing on the left of the title because of the transform origin being in the center. By changing the transform origin to the left edge, the left margin remains consistent.
