### PR TITLE
Force core-toolbar/core-header to be transparent

### DIFF
--- a/core-scroll-header-panel.css
+++ b/core-scroll-header-panel.css
@@ -55,3 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 #condensedHeaderBg {
   opacity: 0;
 }
+
+#headerContent::content > * {
+  background: transparent;
+}


### PR DESCRIPTION
Because `core-toolbar` now has a default background (aa8b336327958382adcae3dcfc43a9cf27292ebc) it breaks `core-scroll-header-panel` since the background color was previously transparent (https://github.com/Polymer/polymer/issues/576). This change forces the content inside of `#headerContent` (either `core-toolbar` or `.core-header`) to be transparent again.

Fixes https://github.com/Polymer/polymer/issues/576
