### PR TITLE
Fixes #8. Remove background color from core-toolbar

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -55,6 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     core-toolbar {
       color: #f1f1f1;
       fill: #f1f1f1;
+      background-color: transparent;
     }
     
     .title {

--- a/demos/demo3.html
+++ b/demos/demo3.html
@@ -46,6 +46,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     core-scroll-header-panel::shadow #headerBg {
       background-image: url(images/bg3.jpg);
     }
+
+    core-toolbar {
+      background-color: transparent;
+    }
     
     .content {
       padding: 10px 30px;

--- a/demos/demo4.html
+++ b/demos/demo4.html
@@ -55,6 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     core-toolbar {
       color: #f1f1f1;
       fill: #f1f1f1;
+      background-color: transparent;
     }
     
     .title {

--- a/demos/demo5.html
+++ b/demos/demo5.html
@@ -55,6 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     core-toolbar {
       color: #f1f1f1;
       fill: #f1f1f1;
+      background-color: transparent;
     }
     
     .title {

--- a/demos/demo6.html
+++ b/demos/demo6.html
@@ -57,6 +57,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       fill: #f1f1f1;
       /* custom toolbar height */
       height: 256px;
+      background-color: transparent;
     }
     
     .title {

--- a/demos/demo7.html
+++ b/demos/demo7.html
@@ -56,6 +56,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     core-toolbar {
       color: #f1f1f1;
       fill: #f1f1f1;
+      background-color: transparent;
     }
     
     .title {

--- a/demos/demo8.html
+++ b/demos/demo8.html
@@ -57,6 +57,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       fill: #f1f1f1;
       /* custom toolbar height */
       height: 256px;
+      background-color: transparent;
     }
     
     .bottom-text {

--- a/demos/demo9.html
+++ b/demos/demo9.html
@@ -60,6 +60,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       border: 1px solid #eee;
       box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
     }
+
+    core-toolbar {
+      background-color: transparent;
+    }
     
     .content {
       padding: 10px 30px;


### PR DESCRIPTION
As an alternative we could put a style inside of `core-scroll-header-panel` that defaults `core-toolbar` to have a transparent background. Not sure which solution is preferable. 
