### PR TITLE
earlier headerHeight is for no use even if you set

### DIFF
--- a/core-scroll-header-panel.html
+++ b/core-scroll-header-panel.html
@@ -193,6 +193,9 @@ that represents a header by adding a `core-header` class to it.
 
     attached: function() {
       this.resizableAttachedHandler();
+      if (this.headerHeight === 0) {
+        this.measureHeaderHeight();
+      }
     },
 
     ready: function() {
@@ -203,10 +206,6 @@ that represents a header by adding a `core-header` class to it.
     detached: function() {
       this.scroller.removeEventListener('scroll', this._scrollHandler);
       this.resizableDetachedHandler();
-    },
-    
-    domReady: function() {
-      this.async('measureHeaderHeight');
     },
 
     get header() {


### PR DESCRIPTION
```
<core-scroll-header-panel headerHeight="125">
...
</core-scroll-header-panel>
```
Even If I set `headerHeight`, `domReady` overwrites it... so we should check if anything set for headerHeight then use it else measure.