### PR TITLE
Add attribute 'fullWindow'

### DIFF
--- a/core-scroll-header-panel.css
+++ b/core-scroll-header-panel.css
@@ -13,6 +13,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   overflow: hidden;
 }
 
+:host([fullWindow]) {
+  min-height: 100%;
+}
+
 #mainContainer {
   position: absolute;
   top: 0;
@@ -26,11 +30,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   overflow-y: auto;
 }
 
+:host([fullWindow]) #mainContainer {
+  position: relative;
+  width: calc(100% - {{!drawerPanel.narrow && drawerPanel.drawerWidth}});
+}
+
 #headerContainer {
   position: absolute;
   top: 0;
   right: 0;
   left: 0;
+}
+
+:host([fullWindow]) #headerContainer {
+  position: fixed;
+  left: {{!drawerPanel.narrow && !drawerPanel.rightDrawer && drawerPanel.drawerWidth}};
+  right: {{!drawerPanel.narrow && drawerPanel.rightDrawer && drawerPanel.drawerWidth}};
 }
 
 .bg-container {

--- a/core-scroll-header-panel.html
+++ b/core-scroll-header-panel.html
@@ -54,6 +54,18 @@ that represents a header by adding a `core-header` class to it.
 <link rel="import" href="../core-resizable/core-resizable.html">
 
 <polymer-element name="core-scroll-header-panel">
+  <style>
+  [data-fullwindow] {
+    height: auto;
+  }
+  [data-fullwindow]::shadow #main {
+    position: relative;
+  }
+  [data-fullwindow]::shadow #drawer,
+  [data-fullwindow]::shadow #scrim {
+    position: fixed;
+  }
+  </style>
 <template>
 
   <link rel="stylesheet" href="core-scroll-header-panel.css">
@@ -94,6 +106,12 @@ that represents a header by adding a `core-header` class to it.
      */
      
     publish: {
+      
+      fullWindow: {
+        value: false,
+        reflect: true
+      },
+      
       /**
        * If true, the header's height will condense to `_condensedHeaderHeight`
        * as the user scrolls down from the top of the content area.
@@ -184,6 +202,7 @@ that represents a header by adding a `core-header` class to it.
     y: 0,
     
     observe: {
+      'fullWindow': 'fullWindowSetup',
       'headerMargin fixed': 'setup'
     },
 
@@ -192,16 +211,17 @@ that represents a header by adding a `core-header` class to it.
     },
 
     attached: function() {
+      this.fullWindowSetup();
       this.resizableAttachedHandler();
     },
 
     ready: function() {
       this._scrollHandler = this.scroll.bind(this);
-      this.scroller.addEventListener('scroll', this._scrollHandler);
     },
     
     detached: function() {
-      this.scroller.removeEventListener('scroll', this._scrollHandler);
+      this.drawerPanel = null;
+      this.scrollObject.removeEventListener('scroll', this._scrollHandler);
       this.resizableDetachedHandler();
     },
     
@@ -319,7 +339,7 @@ that represents a header by adding a `core-header` class to it.
         return;
       }
       
-      var sTop = this.scroller.scrollTop;
+      var sTop = this.fullWindow ? window.pageYOffset : this.$.mainContainer.scrollTop;
       
       var y = Math.min(this.keepCondensedHeader ? 
           this.headerMargin : this.headerHeight, Math.max(0, 
@@ -337,7 +357,35 @@ that represents a header by adding a `core-header` class to it.
       this.y = y;
       
       if (event) {
-        this.fire('scroll', {target: this.scroller}, this, false);
+        this.fire('scroll', {target: this.scrollObject}, this, false);
+      }
+    },
+
+    fullWindowSetup: function() {
+      this.scrollObject && this.scrollObject.removeEventListener('scroll', this._scrollHandler);
+      this.scrollObject = this.fullWindow ? window : this.$.mainContainer;
+      this.scrollObject.addEventListener('scroll', this._scrollHandler);
+      if (this.fullWindow) {
+        this.style.position = 'static';
+        this.style.height = 'auto';
+        if (!this.drawerPanel) {
+          var parent = this.parentNode;
+          while (parent && parent != document.body) {
+            if (parent.drawerWidth) {
+              parent.setAttribute('data-fullwindow', true);
+              this.drawerPanel = parent;
+              break;
+            }
+            parent = parent.parentNode;
+          }
+        }
+      } else {
+        this.style.position = '';
+        this.style.height = '';
+        if (this.drawerPanel) {
+          this.drawerPanel.removeAttribute('data-fullwindow');
+          this.drawerPanel = null;
+        }
       }
     }
 


### PR DESCRIPTION
The attribute 'fullWindow' can be set if `<core-scroll-header-panel>` is used as a 'global' component containing all other visible components (except an optional `<core-drawer-panel>`!).

Setting this attribute fixes issues #1, #15 and #16.

It (optionally) enables "document scroll" [(see the discussion here)](https://github.com/Polymer/core-scroll-header-panel/issues/1).